### PR TITLE
Add variable and insensitive support for none regex mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test/t/servroot

--- a/README
+++ b/README
@@ -16,7 +16,7 @@ nginx_substitutions_filter
         subs_filter_types text/html text/css text/xml;
         subs_filter st(\d*).example.com $1.example.com ir;
         subs_filter a.example.com s.example.com;
-
+        subs_filter http://$host https://$host;
     }
 
   Directives
@@ -51,9 +51,12 @@ nginx_substitutions_filter
     context: *http, server, location*
 
     *subs_filter* allows replacing source string(regular expression or
-    fixed) in the nginx response with destination string. Substitution text
-    may contain variables. More than one substitution rules per location is
-    supported. The meaning of the third flags are:
+    fixed) in the nginx response with destination string. The variables 
+    in matching text is only avaiable under fixed string mode, which means 
+    the matching text could not contain variables if it is a regular 
+    expression. Substitution text may contain variables. More than one 
+    substitution rules per location is supported. 
+    The meaning of the third flags are:
 
     *   *g*(default): Replace all the match strings.
 

--- a/doc/README.google_code_home_page.wiki
+++ b/doc/README.google_code_home_page.wiki
@@ -14,6 +14,7 @@ location / {
     subs_filter_types text/html text/css text/xml;
     subs_filter st(\d*).example.com $1.example.com ir;
     subs_filter a.example.com s.example.com;
+    subs_filter http://$host https://$host;
 
 }
 }}}
@@ -44,8 +45,8 @@ proxy_set_header Accept-Encoding "";
 
 `context:` _http, server, location_
 
-_subs_filter_ allows replacing source string(regular expression or fixed) in the nginx response with destination string. Substitution text may contain variables. More than one substitution rules per location is supported. The meaning of the third flags are:
- * _g_(default): Replace all the match strings.
+_subs_filter_ allows replacing source string(regular expression or fixed) in the nginx response with destination string. The variables in matching text is only avaiable under fixed string mode, which means the matching text could not contain variables if it is a regular expression. Substitution text may contain variables. More than one substitution rules per location is supported. The meaning of the third flags are:
+ * _g_ (default): Replace all the match strings.
  * _i_: Perform a case-insensitive match.
  * _o_: Just replace the first one.
  * _r_: The pattern is treated as a regular expression, default is fixed string.
@@ -70,7 +71,7 @@ git clone git://github.com/yaoweibin/ngx_http_substitutions_filter_module.git
 and then compile nginx with the following option:
 
 {{{
-./configure --add-module=/path/to/module
+./configure --add-module=/path/to/ngx_http_substitutions_filter_module
 }}}
 == Known issue ==
  * Can't substitute the response header.

--- a/doc/README.html
+++ b/doc/README.html
@@ -53,7 +53,9 @@
 <pre>
     subs_filter_types text/html text/css text/xml;
     subs_filter st(\d*).example.com $1.example.com ir;
-    subs_filter a.example.com s.example.com;</pre>
+    subs_filter a.example.com s.example.com;
+    subs_filter http://$host https://$host;
+</pre>
 <p>}</p>
 <p>
 </p>
@@ -81,7 +83,7 @@
 <p><strong>syntax:</strong> <em>subs_filter source_str destination_str [gior] </em></p>
 <p><strong>default:</strong> <em>none</em></p>
 <p><strong>context:</strong> <em>http, server, location</em></p>
-<p><em>subs_filter</em> allows replacing source string(regular expression or fixed) in the nginx response with destination string. Substitution text may contain variables. More than one substitution rules per location is supported. The meaning of the third flags are:</p>
+<p><em>subs_filter</em> allows replacing source string(regular expression or fixed) in the nginx response with destination string. The variables in matching text is only avaiable under fixed string mode, which means the matching text could not contain variables if it is a regular expression. Substitution text may contain variables. More than one substitution rules per location is supported. The meaning of the third flags are:</p>
 <ul>
 <li>
 <p><em>g</em>(default): Replace all the match strings.</p>
@@ -109,7 +111,7 @@
 <p>To install, get the source with subversion:</p>
 <p>git clone <a href="git://github.com/yaoweibin/ngx_http_substitutions_filter_module.git">git://github.com/yaoweibin/ngx_http_substitutions_filter_module.git</a></p>
 <p>and then compile nginx with the following option:</p>
-<p>./configure --add-module=/path/to/module</p>
+<p>./configure --add-module=/path/to/ngx_http_substitutions_filter_module</p>
 <p>
 </p>
 <h2><a name="known_issue">Known issue</a></h2>

--- a/doc/README.wiki
+++ b/doc/README.wiki
@@ -14,6 +14,7 @@ location / {
     subs_filter_types text/html text/css text/xml;
     subs_filter st(\d*).example.com $1.example.com ir;
     subs_filter a.example.com s.example.com;
+    subs_filter http://$host https://$host;
 
 }
 </geshi>
@@ -45,7 +46,7 @@ proxy_set_header Accept-Encoding "";
 
 '''context:''' ''http, server, location''
 
-''subs_filter'' allows replacing source string(regular expression or fixed) in the nginx response with destination string. Substitution text may contain variables. More than one substitution rules per location is supported. The meaning of the third flags are:
+''subs_filter'' allows replacing source string(regular expression or fixed) in the nginx response with destination string. The variables in matching text is only avaiable under fixed string mode, which means the matching text could not contain variables if it is a regular expression. Substitution text may contain variables. More than one substitution rules per location is supported. The meaning of the third flags are:
 * ''g''(default): Replace all the match strings.
 * ''i'': Perform a case-insensitive match.
 * ''o'': Just replace the first one.
@@ -72,7 +73,7 @@ git clone git://github.com/yaoweibin/ngx_http_substitutions_filter_module.git
 and then compile nginx with the following option:
 
 <code>
-./configure --add-module=/path/to/module
+./configure --add-module=/path/to/ngx_http_substitutions_filter_module
 </code>
 
 == Known issue ==

--- a/test/t/subs_none_regex.t
+++ b/test/t/subs_none_regex.t
@@ -1,0 +1,55 @@
+# vi:filetype=perl
+
+use lib 'lib';
+use Test::Nginx::LWP;
+
+plan tests => repeat_each() * 2 * blocks();
+no_root_location();
+
+#no_diff;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: the "substitution" command with build-in variable matching
+--- config
+    location / {
+        subs_filter_types text/plain;
+        subs_filter http://$host https://$host;
+    }
+--- user_files
+>>> foo.txt
+http://localhost
+--- request
+    GET /foo.txt
+--- response_body_like: ^https://localhost$
+
+=== TEST 2: the "substitution" command with custom variable matching
+--- config
+    location / {
+        set $foo foo;
+        subs_filter_types text/plain;
+        subs_filter $foo bar;
+    }
+--- user_files
+>>> foo.txt
+barfoobar
+--- request
+    GET /foo.txt
+--- response_body_like: ^(bar){3}$
+
+=== TEST 3: the "substitution" command with insensitive matching
+--- config
+    location / {
+        subs_filter_types text/plain;
+        subs_filter foobar hello;
+        subs_filter foobar world i;
+    }
+--- user_files
+>>> foo.txt
+FoObAr
+--- request
+    GET /foo.txt
+--- response_body_like: ^world$
+

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,5 +1,40 @@
 #!/bin/sh
 
-#TEST_NGINX_BACKENDS_PORT=127.0.0.1:1234 PATH=/home/yaoweibin/nginx/sbin:$PATH prove -r t
+# 
+# Test::LongString Module of perl is needed
+# You can install it with `cpan install Test::LongString`
+#
 
-PATH=/home/yaoweibin/nginx/sbin:$PATH prove -r t
+#
+# Basic Usage.
+#  TEST_NGINX_SBIN_PATH=/path/to/nginx/sbin \
+#  ./test.sh
+#
+
+#
+# Custom Backend Server
+#  TEST_NGINX_SBIN_PATH=/path/to/nginx/sbin \
+#  TEST_NGINX_BACKENDS_PORT=ip:port \
+#  ./test.sh
+
+TEST_NGINX_SBIN_PATH=${TEST_NGINX_SBIN_PATH:=/path/to/nginx/sbin}
+PATH=$TEST_NGINX_SBIN_PATH:$PATH prove -r t
+
+#
+# The command of @yaoweibin
+#
+# nginx sbin path
+# TEST_NGINX_SBIN_PATH=/home/yaoweibin/nginx/sbin
+
+# 
+# basic test with backend www.taobao.com:80
+#
+# PATH=$TEST_NGINX_SBIN_PATH:$PATH prove -r t
+
+#
+# custom test with custom backend
+#
+# TEST_NGINX_BACKENDS_PORT=127.0.0.1:1234 \
+# PATH=$TEST_NGINX_SBIN_PATH:$PATH prove -r t
+
+


### PR DESCRIPTION
1. make `subs_filter http://$host https://$host;` possible.
2. in none regex mode, use `ngx_strlcasestrn` to avoid regex during insensitive substitutions.