### PR TITLE
Check the content-encoding header more carefully

### DIFF
--- a/ngx_http_subs_filter_module.c
+++ b/ngx_http_subs_filter_module.c
@@ -245,7 +245,9 @@ ngx_http_subs_header_filter(ngx_http_request_t *r)
 
     /* Don't do substitution with the compressed content */
     if (r->headers_out.content_encoding
-        && r->headers_out.content_encoding->value.len) {
+        && r->headers_out.content_encoding->value.len
+        && ngx_strncasecmp(r->headers_out.content_encoding->value.data,
+                            (u_char *) "identity", 8) != 0) {
 
         ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
                       "http subs filter header ignored, this may be a "


### PR DESCRIPTION
```
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy status 200 "200 OK"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "Content-Type: text/css; charset=utf-8"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "Access-Control-Allow-Origin: *"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "Timing-Allow-Origin: *"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "Content-Encoding: identity"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "Content-Length: 273"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "Expires: Sun, 27 Mar 2016 06:41:47 GMT"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "Date: Sun, 27 Mar 2016 06:41:47 GMT"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "Cache-Control: private, max-age=86400"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "X-Content-Type-Options: nosniff"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "X-Frame-Options: SAMEORIGIN"
2016/03/27 14:41:47 [debug] 5476#0: *16 posix_memalign: 0000000001A4CA80:4096 @16
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "X-XSS-Protection: 1; mode=block"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header: "Server: GSE"
2016/03/27 14:41:47 [debug] 5476#0: *16 http proxy header done
2016/03/27 14:41:47 [warn] 5476#0: *16 http subs filter header ignored, this may be a compressed response. while reading response header from upstream, client: 114.65.*.*, server: gfonts-backend.example.com, request: "GET /css?family=Source+Sans+Pro HTTP/2.0", upstream: "https://203.208.40.37:443/css?family=Source+Sans+Pro", host: "gfonts-backend.example.com"
```

The response with default content encoding(identity) which means no compression should not be bypass.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding