### PR TITLE
PCRE2 support added

### DIFF
--- a/ngx_http_subs_filter_module.c
+++ b/ngx_http_subs_filter_module.c
@@ -1248,7 +1248,9 @@ ngx_http_subs_regex_capture_count(ngx_regex_t *re)
 
     n = 0;
 
-#if defined(nginx_version) && nginx_version >= 1002002
+#if (NGX_PCRE2)
+    rc = pcre2_pattern_info(re, PCRE2_INFO_CAPTURECOUNT, &n);
+#elif defined(nginx_version) && nginx_version >= 1002002
     rc = pcre_fullinfo(re->code, NULL, PCRE_INFO_CAPTURECOUNT, &n);
 #elif defined(nginx_version) && nginx_version >= 1001012
     rc = pcre_fullinfo(re->pcre, NULL, PCRE_INFO_CAPTURECOUNT, &n);


### PR DESCRIPTION
Use pcre2_pattern_info call if nginx built with PCRE2.